### PR TITLE
avoid AttributeError for xapian < 1.3

### DIFF
--- a/plugin/nvim.vim
+++ b/plugin/nvim.vim
@@ -153,7 +153,10 @@ class Nvimdb: # {{{
 
     self.tg = xapian.TermGenerator()
     self.tg.set_stemmer( xapian.Stem( self.language ) )
-    self.tg.set_stemming_strategy( self.tg.STEM_SOME )
+    try:
+        self.tg.set_stemming_strategy( self.tg.STEM_SOME )
+    except AttributeError:
+        pass
 
     self.e  = xapian.Enquire(self.db)
     self.sorted_e = xapian.Enquire(self.db)


### PR DESCRIPTION
RHEL v6.4 installs xapian-bindings-python-1.2.7-1.el6.x86_64.rpm which
causes the following exception when starting nvim:

```
$ python
Python 2.6.6 (r266:84292, May 27 2013, 05:35:12)
[GCC 4.4.7 20120313 (Red Hat 4.4.7-3)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import xapian
>>> tg = xapian.TermGenerator()
>>> tg.set_stemmer(xapian.Stem('en'))
>>> tg.set_stemming_strategy( tg.STEM_SOME )
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'TermGenerator' object has no attribute 'set_stemming_strategy'
```

The xapian docs say that `TermGenerator.set_stemming_strategy` was
introduced in 1.3.  I've never used xapian before so it may not be ok to
ignore this exception, but it at least allows nvim to start up.
