### PR TITLE
Force the search window to be on the left

### DIFF
--- a/plugin/nvim.vim
+++ b/plugin/nvim.vim
@@ -110,6 +110,7 @@ endfunction
 " function s:SetupResults {{{
 " creates the results window
 function! s:SetupResults()
+  setlocal nosplitright
   30vnew  _nvim
 
   setlocal noswapfile


### PR DESCRIPTION
If a user has `set splitright` in his `.vimrc`, then the search window will be on the right. This commit prevents that from happening.
